### PR TITLE
TEST-012-Refactor state shape and keep new-todo-input value in the store

### DIFF
--- a/src/components/new-todo-input/new-todo-input.component.js
+++ b/src/components/new-todo-input/new-todo-input.component.js
@@ -2,23 +2,26 @@ import React, { PropTypes } from 'react';
 
 export default class NewTodoInput extends React.PureComponent {
     static propTypes = {
+        addTodo: PropTypes.func.isRequired,
         onTodoChange: PropTypes.func.isRequired,
-        addTodo: PropTypes.func.isRequired
+        text: PropTypes.string
     };
 
-    onAddTodo = () => {
-        this.props.addTodo();
+    handleClick = () => {
+        this.props.addTodo(this.props.text);
     };
 
-    onToDoChange = (event) => {
+    handleToDoChange = (event) => {
         this.props.onTodoChange(event.target.value)
     };
 
     render() {
+        const text = this.props.text;
+
         return (
             <div>
-                <input type="text" name="todo" onChange={this.onToDoChange}/>
-                <button onClick={this.onAddTodo}>Add ToDo</button>
+                <input type="text" value={ text } name="todo" onChange={this.handleToDoChange}/>
+                <button onClick={this.handleClick}>Add ToDo</button>
             </div>
         )
     }

--- a/src/components/new-todo-input/new-todo-input.container.js
+++ b/src/components/new-todo-input/new-todo-input.container.js
@@ -4,11 +4,16 @@ import {
     onTodoChange,
     addTodo
 } from '../../state/todo-list/todo-list.actions';
+import { selectNewTodo } from '../../state/new-todo-input/new-todo-input.selectors';
 import WhyDidYouUpdate from '../../utils/perf/why-did-you-update';
+
+const mapStateToProps = state => ({
+    text: selectNewTodo(state)
+});
 
 const mapDispatchToProps = ({
     onTodoChange,
     addTodo
 });
 
-export default connect(null, mapDispatchToProps)(WhyDidYouUpdate(NewTodoInput));
+export default connect(mapStateToProps, mapDispatchToProps)(WhyDidYouUpdate(NewTodoInput));

--- a/src/components/todo-list/todo-list.component.js
+++ b/src/components/todo-list/todo-list.component.js
@@ -1,4 +1,6 @@
 import React, { PropTypes } from 'react';
+
+// change this to '../todo/todo.component' and see how many re-renders are triggered!
 import Todo from '../todo/todo.container';
 
 export default class TodoList extends React.PureComponent {

--- a/src/components/todo/todo.component.js
+++ b/src/components/todo/todo.component.js
@@ -16,12 +16,13 @@ export default class Todo extends React.Component {
     // tries to trigger one, as the whole point of shouldComponentUpdate is to stop wasteful re-renders!  
     //
     // To detect wasteful mapStateToProps, use the WhyDidYouUpdate HoC
-    shouldComponentUpdate(nextProps, nextState) {
-        return !(
-            nextProps.todo.text === this.props.todo.text
-            && nextProps.todo.completed === this.props.todo.completed
-        );
-    }
+
+    // shouldComponentUpdate(nextProps, nextState) {
+    //     return !(
+    //         nextProps.todo.text === this.props.todo.text
+    //         && nextProps.todo.completed === this.props.todo.completed
+    //     );
+    // }
 
     render() {
         const { todo } = this.props;

--- a/src/state/new-todo-input/new-todo-input.selectors.js
+++ b/src/state/new-todo-input/new-todo-input.selectors.js
@@ -1,0 +1,3 @@
+import { TODO_LIST, NEW_TODO, TEXT } from '../../constants/todo-list/todo-list.constants';
+
+export const selectNewTodo = state => state[TODO_LIST][NEW_TODO][TEXT];

--- a/src/state/todo-list/initial.state.js
+++ b/src/state/todo-list/initial.state.js
@@ -2,5 +2,7 @@ import * as todoListConstants from '../../constants/todo-list/todo-list.constant
 
 export default {
     [todoListConstants.TODOS]: {},
-    [todoListConstants.NEW_TODO]: ''
+    [todoListConstants.NEW_TODO]: {
+        [todoListConstants.TEXT]: ''
+    }
 };

--- a/src/state/todo-list/todo-list.reducers.js
+++ b/src/state/todo-list/todo-list.reducers.js
@@ -1,8 +1,8 @@
+import update from 'update-immutable';
 import { keys } from 'ramda';
 import { handleActions } from 'redux-actions';
 import initialState from './initial.state';
 import * as todoListConstants from '../../constants/todo-list/todo-list.constants';
-import update from 'update-immutable';
 
 export default handleActions({
     [todoListConstants.TODO_LIST_ADD_TODO]: addTodo,
@@ -10,11 +10,12 @@ export default handleActions({
     [todoListConstants.TODO_LIST_TOGGLE_COMPLETED]: toggleCompleted
 }, initialState);
 
+////// SLICE REDUCERS //////
 
-function addTodo(state) {
+function addTodo(state, action) {
     const [...todos] = keys(state[todoListConstants.TODOS]);
     const id = todos ? todos.length : 0;
-    const text = state[todoListConstants.NEW_TODO];
+    const text = action.payload;
 
     return update(state, {
         [todoListConstants.TODOS]: {
@@ -32,7 +33,9 @@ function addTodo(state) {
 function todoChange(state, action) {
     return update(state, {
         [todoListConstants.NEW_TODO]: {
-            $set: action.payload
+            [todoListConstants.TEXT]: {
+                $set: action.payload
+            }
         }
     });
 }

--- a/src/state/todo-list/todo-list.selectors.js
+++ b/src/state/todo-list/todo-list.selectors.js
@@ -37,6 +37,6 @@ export const getAllTodosUnmemoized = compose(values, selectToDos);
 export default {
     // change this to getAllTodosUnmemoized or getAllTodosMemoized, depending on whether you want to use an 
     // unmemoized or memoized selector
-    getAllTodos: getAllTodosUnmemoized
+    getAllTodos: getAllTodosMemoized
 };
 


### PR DESCRIPTION
`new-todo-input` state shape is subtly different. More importantly, the `new-todo-input` value is kept in the store, making the re-renders much more predictable.